### PR TITLE
Make it possible to react to connections being opened and closed

### DIFF
--- a/src/main/php/websocket/Listener.class.php
+++ b/src/main/php/websocket/Listener.class.php
@@ -1,13 +1,29 @@
 <?php namespace websocket;
 
-interface Listener {
+abstract class Listener {
+
+  /**
+   * Opens connection
+   *
+   * @param  websocket.protocol.Connection $connection
+   * @return void
+   */
+  public function open($connection) { /* NOOP */ }
 
   /**
    * Listens for messages
    *
-   * @param  websocket.protocol.Connection
-   * @param  string|util.Bytes
+   * @param  websocket.protocol.Connection $connection
+   * @param  string|util.Bytes $message
    * @return var
    */
-  public function message($connection, $message);
+  public abstract function message($connection, $message);
+
+  /**
+   * Closes connection
+   *
+   * @param  websocket.protocol.Connection $connection
+   * @return void
+   */
+  public function close($connection) { /* NOOP */ }
 }

--- a/src/main/php/websocket/Listeners.class.php
+++ b/src/main/php/websocket/Listeners.class.php
@@ -36,7 +36,7 @@ abstract class Listeners implements Value {
    * Finds listener for a given path, returning NULL otherwise
    *
    * @param  string $path
-   * @return ?callable
+   * @return ?websocket.Listener
    */
   public function listener($path) {
     foreach ($this->paths as $pattern => $listener) {
@@ -49,14 +49,14 @@ abstract class Listeners implements Value {
    * Cast listeners
    *
    * @param  websocket.Listener|function(websocket.protocol.Connection, string|util.Bytes): var $arg
-   * @return callable
+   * @return websocket.Listener
    * @throws lang.IllegalArgumentException
    */
   public static function cast($arg) {
     if ($arg instanceof Listener) {
-      return [$arg, 'message'];
-    } else if (is_callable($arg)) {
       return $arg;
+    } else if (is_callable($arg)) {
+      return newinstance(Listener::class, [], ['message' => $arg]);
     } else {
       throw new IllegalArgumentException('Expected either a callable or a websocket.Listener instance, have '.typeof($arg));
     }

--- a/src/main/php/websocket/protocol/Handshake.class.php
+++ b/src/main/php/websocket/protocol/Handshake.class.php
@@ -7,13 +7,17 @@
  * @test  xp://websocket.unittest.HandshakeTest
  */
 class Handshake {
-  const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+  const GUID= '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
   private $listeners, $logging;
 
   public function __construct($listeners, $logging) {
     $this->listeners= $listeners;
     $this->logging= $logging;
+  }
+
+  public function start($socket, $i) {
+    // NOOP
   }
 
   public function next($socket, $i) {
@@ -64,7 +68,7 @@ class Handshake {
           $accept
         ));
         $socket->setTimeout(600.0);
-        $this->listeners->connections[$i]= new Connection($socket, $i, $listener, $headers);
+        $this->listeners->connections[$i]= new Connection($socket, $i, $listener, $path, $headers);
         $this->logging->log($i, $method.' '.$path, 101);
         return Messages::class;
 

--- a/src/main/php/websocket/protocol/Messages.class.php
+++ b/src/main/php/websocket/protocol/Messages.class.php
@@ -11,6 +11,10 @@ class Messages {
     $this->logging= $logging;
   }
 
+  public function start($socket, $i) {
+    $this->listeners->connections[$i]->open();
+  }
+
   public function next($socket, $i) {
     $conn= $this->listeners->connections[$i];
     foreach ($conn->receive() as $opcode => $payload) {
@@ -63,15 +67,14 @@ class Messages {
         }
       } catch (Throwable $t) {
         $this->logging->log($i, Opcodes::nameOf($opcode), $t);
-      } catch (\Throwable $t) {  // PHP 7
+      } catch (\Throwable $t) {
         $this->logging->log($i, Opcodes::nameOf($opcode), Throwable::wrap($t));
-      } catch (\Exception $e) {  // PHP 5
-        $this->logging->log($i, Opcodes::nameOf($opcode), Throwable::wrap($e));
       }
     }
   }
 
   public function end($socket, $i) {
+    $this->listeners->connections[$i]->close();
     unset($this->listeners->connections[$i]);
   }
 }

--- a/src/main/php/xp/websockets/Protocol.class.php
+++ b/src/main/php/xp/websockets/Protocol.class.php
@@ -14,11 +14,13 @@ class Protocol implements Handler {
 
   public function open($events, $socket, $i) {
     $this->flow[$i]= $this->flow[Handshake::class];
+    $this->flow[$i]->start($socket, $i);
   }
 
   public function data($events, $socket, $i) {
     if ($next= $this->flow[$i]->next($socket, $i)) {
       $this->flow[$i]= $this->flow[$next];
+      $this->flow[$i]->start($socket, $i);
     }
   }
 

--- a/src/test/php/websocket/unittest/ListenersTest.class.php
+++ b/src/test/php/websocket/unittest/ListenersTest.class.php
@@ -22,7 +22,7 @@ class ListenersTest {
   #[Test]
   public function cast_function() {
     $f= function($conn, $message) { };
-    Assert::equals($f, Listeners::cast($f));
+    Assert::instance(Listener::class, Listeners::cast($f));
   }
 
   #[Test]
@@ -30,7 +30,7 @@ class ListenersTest {
     $l= newinstance(Listener::class, [], [
       'message' =>  function($conn, $message) { }
     ]);
-    Assert::equals([$l, 'message'], Listeners::cast($l));
+    Assert::instance(Listener::class, Listeners::cast($l));
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
@@ -72,7 +72,7 @@ class ListenersTest {
       ];
     });
     $listener= $listeners->listener($path);
-    Assert::equals($expected, $listener(null, 'Test'));
+    Assert::equals($expected, $listener->message(null, 'Test'));
   }
 
   #[Test]

--- a/src/test/php/websocket/unittest/MessagesTest.class.php
+++ b/src/test/php/websocket/unittest/MessagesTest.class.php
@@ -33,7 +33,7 @@ class MessagesTest {
 
     // Simulate handshake
     $channel->connect();
-    $listeners->connections[self::ID]= new Connection($channel, self::ID, $listener, []);
+    $listeners->connections[self::ID]= new Connection($channel, self::ID, $listeners->listener('/ws'), []);
 
     return new Messages($listeners, $this->log);
   }


### PR DESCRIPTION
This pull request makes adds *open()* and *close()* hooks to listeners. Both are implemented as NOOP by default and can be overridden. Example:

```php
$listener= new class($events) extends Listener {

  public function open($conn) {
    // Connection opened
  }

  public function message($conn, $data) {
    // Message received
  }

  public function close($conn) {
    // Connection closed
  }
};
```