### PR TITLE
Add ability to pass path to constructor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,8 @@ WebSockets change log
 * **Heads up**: Deprecated passing origin to `WebSocket` constructor. It
   should be passed inside the headers when calling *connect()*.
   (@thekid)
-* Added ability to pass path and query string to `WebSocket` constructor
+* Merged PR #7: Added ability to pass path and query string to `WebSocket`
+  constructor
   (@thekid)
 * Fixed "Call to a member function message() on null" errors when using
   an already connected socket in the `WebSocket` constructor.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,13 @@ WebSockets change log
 
 ## ?.?.? / ????-??-??
 
-* Fix "Call to a member function message() on null" errors when using an
-  already connected socket in the `WebSocket` constructor.
+* **Heads up**: Deprecated passing origin to `WebSocket` constructor. It
+  should be passed inside the headers when calling *connect()*.
+  (@thekid)
+* Added ability to pass path and query string to `WebSocket` constructor
+  (@thekid)
+* Fixed "Call to a member function message() on null" errors when using
+  an already connected socket in the `WebSocket` constructor.
   (@thekid)
 
 ## 4.0.0 / 2024-10-05

--- a/src/main/php/websocket/WebSocket.class.php
+++ b/src/main/php/websocket/WebSocket.class.php
@@ -11,7 +11,7 @@ use websocket\protocol\{Connection, Handshake, Opcodes};
  * @test  websocket.unittest.WebSocketTest
  */
 class WebSocket implements Closeable {
-  private $socket, $path;
+  private $socket, $path, $headers;
   private $conn= null;
   private $listener= null;
   private $random= 'random_bytes';
@@ -20,22 +20,34 @@ class WebSocket implements Closeable {
    * Creates a new instance
    *
    * @param  peer.Socket|string $endpoint, e.g. "wss://example.com"
-   * @param  string $path
+   * @param  ?string $path
    */
-  public function __construct($endpoint, $path= '/') {
+  public function __construct($endpoint, $path= null) {
     if ($endpoint instanceof Socket) {
       $this->socket= $endpoint;
-      $this->path= $path;
+      $this->headers= ['Host' => $this->socket->host];
+      $this->path= '/';
     } else {
       $url= parse_url($endpoint);
+      $this->headers= ['Host' => $url['host']];
       if ('wss' === $url['scheme']) {
         $this->socket= new CryptoSocket($url['host'], $url['port'] ?? 443);
         $this->socket->cryptoImpl= STREAM_CRYPTO_METHOD_ANY_CLIENT;
       } else {
         $this->socket= new Socket($url['host'], $url['port'] ?? 80);
       }
-      $this->path= $url['path'] ?? $path;
+      $this->path= $url['path'] ?? '/';
       isset($url['query']) && $this->path.= '?'.$url['query'];
+    }
+
+    // BC: Older versions accepted origin as second parameter
+    if (null === $path) {
+      // NOOP
+    } else if ('/' === $path[0] ?? null) {
+      $this->path= $path;
+    } else {
+      $this->path= '/';
+      $this->headers['Origin']= $path;
     }
   }
 
@@ -44,6 +56,14 @@ class WebSocket implements Closeable {
 
   /** @return string */
   public function path() { return $this->path; }
+
+  /**
+   * Returns origin set via constructor
+   *
+   * @deprecated Pass the origin to `connect()` instead!
+   * @return ?string
+   */
+  public function origin() { return $this->headers['Origin'] ?? null; }
 
   /** @return bool */
   public function connected() { return null !== $this->conn; }
@@ -76,7 +96,6 @@ class WebSocket implements Closeable {
     if ($this->conn) return;
 
     $key= base64_encode(($this->random)(16));
-    $headers+= ['Host' => $this->socket->host];
     $this->socket->isConnected() || $this->socket->connect();
     $this->socket->write(
       "GET {$this->path} HTTP/1.1\r\n".
@@ -85,7 +104,7 @@ class WebSocket implements Closeable {
       "Sec-WebSocket-Version: 13\r\n".
       "Connection: Upgrade\r\n"
     );
-    foreach ($headers as $name => $values) {
+    foreach ($headers + $this->headers as $name => $values) {
       foreach ((array)$values as $value) {
         $this->socket->write("{$name}: {$value}\r\n");
       }

--- a/src/main/php/websocket/WebSocket.class.php
+++ b/src/main/php/websocket/WebSocket.class.php
@@ -209,7 +209,6 @@ class WebSocket implements Closeable {
           $close= unpack('ncode/a*reason', $packet);
           $this->conn->close($close['code'], $close['reason']);
           $this->conn= null;
-          $this->socket->close();
 
           // 1000 is a normal close, all others indicate an error
           if (1000 === $close['code']) return null;
@@ -237,7 +236,6 @@ class WebSocket implements Closeable {
 
     $this->conn->close($code, $reason);
     $this->conn= null;
-    $this->socket->close();
   }
 
   /** Destructor - ensures connection is closed */

--- a/src/test/php/websocket/unittest/WebSocketTest.class.php
+++ b/src/test/php/websocket/unittest/WebSocketTest.class.php
@@ -49,7 +49,7 @@ class WebSocketTest {
     Assert::equals($s, (new WebSocket($s))->socket());
   }
 
-  #[Test, Values([[null, '/'], ['/', '/'], ['/sub', '/sub']])]
+  #[Test, Values([[null, '/'], ['/', '/'], ['/sub', '/sub'], ['/?test=1&l=de', '/?test=1&l=de']])]
   public function socket_path($path, $expected) {
     $s= new Socket('example.com', 8443);
     Assert::equals($expected, (new WebSocket($s, $path))->path());

--- a/src/test/php/websocket/unittest/WebSocketTest.class.php
+++ b/src/test/php/websocket/unittest/WebSocketTest.class.php
@@ -32,16 +32,6 @@ class WebSocketTest {
   }
 
   #[Test]
-  public function default_origin() {
-    Assert::equals('localhost', (new WebSocket('ws://example.com'))->origin());
-  }
-
-  #[Test]
-  public function origin() {
-    Assert::equals('example.com', (new WebSocket('ws://example.com', 'example.com'))->origin());
-  }
-
-  #[Test]
   public function socket_argument() {
     $s= new Socket('example.com', 8443);
     Assert::equals($s, (new WebSocket($s))->socket());
@@ -154,6 +144,40 @@ class WebSocketTest {
   }
 
   #[Test]
+  public function handshake() {
+    $fixture= $this->fixture();
+    $fixture->connect();
+
+    Assert::equals(
+      "GET / HTTP/1.1\r\n".
+      "Upgrade: websocket\r\n".
+      "Sec-WebSocket-Key: KioqKioqKioqKioqKioqKg==\r\n".
+      "Sec-WebSocket-Version: 13\r\n".
+      "Connection: Upgrade\r\n".
+      "Host: test\r\n\r\n",
+      $fixture->socket()->out
+    );
+  }
+
+  #[Test]
+  public function sends_headers() {
+    $fixture= $this->fixture();
+    $fixture->connect(['Origin' => 'example.com', 'Sec-WebSocket-Protocol' => 'wamp']);
+
+    Assert::equals(
+      "GET / HTTP/1.1\r\n".
+      "Upgrade: websocket\r\n".
+      "Sec-WebSocket-Key: KioqKioqKioqKioqKioqKg==\r\n".
+      "Sec-WebSocket-Version: 13\r\n".
+      "Connection: Upgrade\r\n".
+      "Origin: example.com\r\n".
+      "Sec-WebSocket-Protocol: wamp\r\n".
+      "Host: test\r\n\r\n",
+      $fixture->socket()->out
+    );
+  }
+
+  #[Test]
   public function send_text() {
     $fixture= $this->fixture();
     $fixture->connect();
@@ -165,8 +189,7 @@ class WebSocketTest {
       "Sec-WebSocket-Key: KioqKioqKioqKioqKioqKg==\r\n".
       "Sec-WebSocket-Version: 13\r\n".
       "Connection: Upgrade\r\n".
-      "Host: test\r\n".
-      "Origin: localhost\r\n\r\n".
+      "Host: test\r\n\r\n".
       "\x81\x84****\176\117\131\136",
       $fixture->socket()->out
     );
@@ -184,8 +207,7 @@ class WebSocketTest {
       "Sec-WebSocket-Key: KioqKioqKioqKioqKioqKg==\r\n".
       "Sec-WebSocket-Version: 13\r\n".
       "Connection: Upgrade\r\n".
-      "Host: test\r\n".
-      "Origin: localhost\r\n\r\n".
+      "Host: test\r\n\r\n".
       "\x82\x88****\155\143\154\022\023\004\004\004",
       $fixture->socket()->out
     );
@@ -203,8 +225,7 @@ class WebSocketTest {
       "Sec-WebSocket-Key: KioqKioqKioqKioqKioqKg==\r\n".
       "Sec-WebSocket-Version: 13\r\n".
       "Connection: Upgrade\r\n".
-      "Host: test\r\n".
-      "Origin: localhost\r\n\r\n".
+      "Host: test\r\n\r\n".
       "\x8a\x81****\013",
       $fixture->socket()->out
     );

--- a/src/test/php/websocket/unittest/WebSocketTest.class.php
+++ b/src/test/php/websocket/unittest/WebSocketTest.class.php
@@ -31,10 +31,28 @@ class WebSocketTest {
     Assert::equals($expected, (new WebSocket($url))->path());
   }
 
+  /** @deprecated */
+  #[Test]
+  public function default_origin() {
+    Assert::null((new WebSocket('ws://example.com'))->origin());
+  }
+
+  /** @deprecated */
+  #[Test]
+  public function origin_via_constructor() {
+    Assert::equals('example.com', (new WebSocket('ws://example.com', 'example.com'))->origin());
+  }
+
   #[Test]
   public function socket_argument() {
     $s= new Socket('example.com', 8443);
     Assert::equals($s, (new WebSocket($s))->socket());
+  }
+
+  #[Test, Values([[null, '/'], ['/', '/'], ['/sub', '/sub']])]
+  public function socket_path($path, $expected) {
+    $s= new Socket('example.com', 8443);
+    Assert::equals($expected, (new WebSocket($s, $path))->path());
   }
 
   #[Test, Values([['ws://example.com', 80], ['wss://example.com', 443]])]

--- a/src/test/php/websocket/unittest/WebSocketTest.class.php
+++ b/src/test/php/websocket/unittest/WebSocketTest.class.php
@@ -180,7 +180,7 @@ class WebSocketTest {
   #[Test]
   public function sends_headers() {
     $fixture= $this->fixture();
-    $fixture->connect(['Origin' => 'example.com', 'Sec-WebSocket-Protocol' => 'wamp']);
+    $fixture->connect(['Origin' => 'example.com', 'Sec-WebSocket-Protocol' => ['wamp', 'soap']]);
 
     Assert::equals(
       "GET / HTTP/1.1\r\n".
@@ -190,6 +190,7 @@ class WebSocketTest {
       "Connection: Upgrade\r\n".
       "Origin: example.com\r\n".
       "Sec-WebSocket-Protocol: wamp\r\n".
+      "Sec-WebSocket-Protocol: soap\r\n".
       "Host: test\r\n\r\n",
       $fixture->socket()->out
     );


### PR DESCRIPTION
Example:

```php
$ws= new WebSocket($socket, '/ws');
```

⚠️ **Note**: The *WebSocket* constructor previously accepted the origin as its second argument. This is still supported but deprecated in favor of passing it to `connect()`!