### PR TITLE
Add Connection::params() to access parameters passed in handshake request

### DIFF
--- a/src/main/php/websocket/protocol/Connection.class.php
+++ b/src/main/php/websocket/protocol/Connection.class.php
@@ -56,6 +56,16 @@ class Connection {
   public function headers() { return $this->headers; }
 
   /**
+   * Returns a named parameter, or NULL if it does not exist.
+   *
+   * @param  string $name
+   * @return var
+   */
+  public function param($name) {
+    return $this->params[$name] ?? null;
+  }
+
+  /**
    * Opens connection
    * 
    * @return void

--- a/src/main/php/websocket/protocol/Connection.class.php
+++ b/src/main/php/websocket/protocol/Connection.class.php
@@ -59,10 +59,11 @@ class Connection {
    * Returns a named parameter, or NULL if it does not exist.
    *
    * @param  string $name
+   * @param  var $default
    * @return var
    */
-  public function param($name) {
-    return $this->params[$name] ?? null;
+  public function param($name, $default= null) {
+    return $this->params[$name] ?? $default;
   }
 
   /**

--- a/src/main/php/websocket/protocol/Connection.class.php
+++ b/src/main/php/websocket/protocol/Connection.class.php
@@ -12,7 +12,7 @@ use websocket\Listener;
 class Connection {
   const MAXLENGTH= 0x8000000;
 
-  private $socket, $id, $listener, $path, $headers;
+  private $socket, $id, $listener, $path, $params, $headers;
 
   /**
    * Creates a new connection
@@ -27,7 +27,16 @@ class Connection {
     $this->socket= $socket;
     $this->id= $id;
     $this->listener= $listener;
-    $this->path= $path;
+
+    $p= strpos($path, '?');
+    if (false === $p) {
+      $this->path= $path;
+      $this->params= [];
+    } else {
+      $this->path= substr($path, 0, $p);
+      parse_str(substr($path, $p + 1), $this->params);
+    }
+
     $this->headers= $headers;
   }
 
@@ -39,6 +48,9 @@ class Connection {
 
   /** @return string */
   public function path() { return $this->path; }
+
+  /** @return [:var] */
+  public function params() { return $this->params; }
 
   /** @return [:var] */
   public function headers() { return $this->headers; }

--- a/src/test/php/websocket/unittest/ConnectionTest.class.php
+++ b/src/test/php/websocket/unittest/ConnectionTest.class.php
@@ -61,15 +61,23 @@ class ConnectionTest {
 
   #[Test, Values(['/?for=test', '/ws?for=test', '/feed/6100?for=test'])]
   public function params($value) {
-    Assert::equals(['for' => 'test'], (new Connection(new Channel(), self::ID, $this->listener(), $value))->params());
+    $conn= new Connection(new Channel(), self::ID, $this->listener(), $value);
+
+    Assert::equals('test', $conn->param('for'));
+    Assert::equals(['for' => 'test'], $conn->params());
+  }
+
+  #[Test]
+  public function non_existant_param() {
+    Assert::null((new Connection(new Channel(), self::ID, $this->listener(), '?for=test'))->param('non-existant'));
   }
 
   #[Test]
   public function array_param() {
-    Assert::equals(
-      ['for' => ['a', 'b']],
-      (new Connection(new Channel(), self::ID, $this->listener(), '?for[]=a&for[]=b'))->params()
-      );
+    $conn= new Connection(new Channel(), self::ID, $this->listener(), '?for[]=a&for[]=b');
+
+    Assert::equals(['a', 'b'], $conn->param('for'));
+    Assert::equals(['for' => ['a', 'b']], $conn->params());
   }
 
   #[Test, Values([[[]], [['User-Agent' => 'Test', 'Accept' => '*/*']]])]

--- a/src/test/php/websocket/unittest/ConnectionTest.class.php
+++ b/src/test/php/websocket/unittest/ConnectionTest.class.php
@@ -69,7 +69,10 @@ class ConnectionTest {
 
   #[Test]
   public function non_existant_param() {
-    Assert::null((new Connection(new Channel(), self::ID, $this->listener(), '?for=test'))->param('non-existant'));
+    $conn= new Connection(new Channel(), self::ID, $this->listener(), '?for=test');
+
+    Assert::null($conn->param('non-existant'));
+    Assert::equals('default', $conn->param('non-existant', 'default'));
   }
 
   #[Test]

--- a/src/test/php/websocket/unittest/ConnectionTest.class.php
+++ b/src/test/php/websocket/unittest/ConnectionTest.class.php
@@ -25,7 +25,7 @@ class ConnectionTest {
    * @return []
    */
   private function receive($channel) {
-    $conn= new Connection($channel->connect(), self::ID, $this->listener(), []);
+    $conn= new Connection($channel->connect(), self::ID, $this->listener());
     $r= [];
     foreach ($conn->receive() as $type => $message) {
       $r[]= [$type => $message];
@@ -52,6 +52,24 @@ class ConnectionTest {
   #[Test, Values(['/', '/ws', '/feed/6100'])]
   public function path($value) {
     Assert::equals($value, (new Connection(new Channel(), self::ID, $this->listener(), $value))->path());
+  }
+
+  #[Test]
+  public function path_does_not_contain_params() {
+    Assert::equals('/', (new Connection(new Channel(), self::ID, $this->listener(), '/?for=test'))->path());
+  }
+
+  #[Test, Values(['/?for=test', '/ws?for=test', '/feed/6100?for=test'])]
+  public function params($value) {
+    Assert::equals(['for' => 'test'], (new Connection(new Channel(), self::ID, $this->listener(), $value))->params());
+  }
+
+  #[Test]
+  public function array_param() {
+    Assert::equals(
+      ['for' => ['a', 'b']],
+      (new Connection(new Channel(), self::ID, $this->listener(), '?for[]=a&for[]=b'))->params()
+      );
   }
 
   #[Test, Values([[[]], [['User-Agent' => 'Test', 'Accept' => '*/*']]])]

--- a/src/test/php/websocket/unittest/MessagesTest.class.php
+++ b/src/test/php/websocket/unittest/MessagesTest.class.php
@@ -33,7 +33,7 @@ class MessagesTest {
 
     // Simulate handshake
     $channel->connect();
-    $listeners->connections[self::ID]= new Connection($channel, self::ID, $listeners->listener('/ws'), []);
+    $listeners->connections[self::ID]= new Connection($channel, self::ID, $listeners->listener('/ws'));
 
     return new Messages($listeners, $this->log);
   }


### PR DESCRIPTION
```diff
 class Chat extends Listener {

   public function open($connection) {
  
-    // FIXME: Connection should have path and params separately
-    $path= $connection->path();
-    parse_str(substr($path, strpos($path, '?') + 1), $params);
  
-    if ($for= $params['for'] ?? null) {
+    if ($for= $connection->param('for')) {
       $this->clients->subscribe($connection->id(), $for);
     }
   }

   // ...
 }
```